### PR TITLE
Add code scanning

### DIFF
--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -1,0 +1,20 @@
+# https://github.com/marketplace/actions/electronegativity
+name: Security analysis
+on: [push]
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Dependencies
+        run: yarn
+      - uses: doyensec/electronegativity-action@v1.1
+      - uses: github/codeql-action/upload-sarif@v1

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -1,6 +1,6 @@
 # https://github.com/marketplace/actions/electronegativity
 name: Security analysis
-on: [push]
+on: [push, pull_request]
 
 jobs:
   analyze:


### PR DESCRIPTION
This pull requests adds security code scanner action. Results are visible in Security tab to maintainers only.
The scanner is specific to Electron.js and may be a good addition to the existing Sonar scan.
Cheers!